### PR TITLE
Update meta and learn to love ansible-lint again

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,12 +4,13 @@ galaxy_info:
 
   license: MIT
 
-  min_ansible_version: 2.9.7
+  min_ansible_version: 2.9.10
 
   platforms:
   - name: Fedora
     versions:
       - 32
+      - 33
 
   galaxy_tags:
     - workstation

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -262,7 +262,7 @@
     - msimonson-anonymouspro-fonts
     - overpass-fonts
     - terminus-fonts
-  state: installed
+    state: installed
   when: install_extra_fonts
 
 - name: Install RPMFusion Packages

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -3,10 +3,10 @@
 - name: Upgrade all packages
   dnf:
     name: "*"
-    state: latest
+    state: latest # noqa 403 This is a workstation playbook and updating your software to the latest versions is a good idea
 
 - name: Install group packages
-  dnf: 
+  dnf:
     name:
       - "@development tools"
       - "@fedora-packager"
@@ -14,7 +14,7 @@
     state: installed
 
 - name: Install extra packages
-  dnf: 
+  dnf:
     name:
     - acpi
     - android-tools
@@ -206,7 +206,7 @@
     state: installed
 
 - name: Install RPM packager packages
-  dnf: 
+  dnf:
     name:
     - blender-rpm-macros
     - erlang-rpm-macros
@@ -243,7 +243,7 @@
   when: install_packager
 
 - name: Install extra fonts
-  dnf: 
+  dnf:
     name:
     - adobe-source-code-pro-fonts
     - dejavu-sans-fonts

--- a/tasks/repos.yml
+++ b/tasks/repos.yml
@@ -13,6 +13,8 @@
 
     - name: Enable Google Chrome repo
       command: dnf config-manager --set-enabled google-chrome
+      args:
+        warn: false
 
   when: install_chrome
 
@@ -103,11 +105,24 @@
 
 - block:
 
-   - name: Install RPMFusion repo rpms
-     dnf:
-       name:
-         - "http://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-{{ ansible_distribution_version }}.noarch.rpm"
-         - "http://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-{{ ansible_distribution_version }}.noarch.rpm"
-       state: present
+    - name: Check for RPM Fusion Free repo
+      stat: path=/etc/yum.repos.d/rpmfusion-free.repo
+      register: fedora_rpm_fusion_free_installed
+
+    - name: Check for RPM Fusion Nonfree repo
+      stat: path=/etc/yum.repos.d/rpmfusion-nonfree.repo
+      register: fedora_rpm_fusion_nonfree_installed
+
+    - name: Install RPM Fusion repo rpms
+      dnf:
+        name: "http://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-{{ ansible_distribution_version }}.noarch.rpm"
+        state: present
+      when: not fedora_rpm_fusion_free_installed.stat.exists
+
+    - name: Install RPM Fusion Nonfree repo rpms
+      dnf:
+        name: "http://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-{{ ansible_distribution_version }}.noarch.rpm"
+        state: present
+      when: not fedora_rpm_fusion_nonfree_installed.stat.exists
 
   when: install_rpmfusion

--- a/tasks/repos.yml
+++ b/tasks/repos.yml
@@ -9,11 +9,11 @@
       dnf:
         name: 'https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm'
         state: present
-      when: chrome_installed.stat.exists == False
+      when: not chrome_installed.stat.exists
 
     - name: Enable Google Chrome repo
-      command: dnf config-manager --set-enabled google-chrome 
-  
+      command: dnf config-manager --set-enabled google-chrome
+
   when: install_chrome
 
 - block:
@@ -26,8 +26,7 @@
       dnf:
         name: 'https://dl.google.com/linux/direct/google-talkplugin_current_x86_64.rpm'
         state: present
-      when: googletalk_installed.stat.exists == False
-
+      when: not googletalk_installed.stat.exists
   when: install_googletalk
 
 - block:
@@ -38,7 +37,7 @@
 
     - name: Install fedora-spotify repo
       command: dnf config-manager --add-repo=https://negativo17.org/repos/fedora-spotify.repo
-      when: fedora_spotify_installed.stat.exists == False
+      when: not fedora_spotify_installed.stat.exists
 
   when: install_spotify
 
@@ -50,7 +49,7 @@
 
     - name: Install sublime-text repo
       command: dnf config-manager --add-repo https://download.sublimetext.com/rpm/stable/x86_64/sublime-text.repo
-      when: fedora_sublime_text_installed.stat.exists == False
+      when: not fedora_sublime_text_installed.stat.exists
 
   when: install_sublime_text
 
@@ -73,7 +72,7 @@
         baseurl: 'https://packages.microsoft.com/yumrepos/vscode'
         gpgkey: 'https://packages.microsoft.com/keys/microsoft.asc'
         gpgcheck: yes
-      when: fedora_vscode_installed.stat.exists == False
+      when: not fedora_vscode_installed.stat.exists
 
   when: install_vscode
 
@@ -98,17 +97,17 @@
         metadata_expire: '300'
         sslverify: yes
         sslcacert: /etc/pki/tls/certs/ca-bundle.crt
-      when: fedora_slack_installed.stat.exists == False
+      when: not fedora_slack_installed.stat.exists
 
   when: install_slack
 
-- block: 
+- block:
 
-   - name: 
+   - name: Install RPMFusion repo rpms
      dnf:
        name:
          - "http://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-{{ ansible_distribution_version }}.noarch.rpm"
          - "http://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-{{ ansible_distribution_version }}.noarch.rpm"
        state: present
-  
+
   when: install_rpmfusion

--- a/tasks/thirdparty.yml
+++ b/tasks/thirdparty.yml
@@ -55,8 +55,6 @@
     name:
       - slack
     state: present
-  when: slack_installed.stat.exists == False
-
 
 - block:
 
@@ -68,7 +66,7 @@
     dnf:
       name: 'https://zoom.us/client/latest/zoom_x86_64.rpm'
       state: present
-    when: zoom_installed.stat.exists == False
+    when: not zoom_installed.stat.exists
 
   when: install_zoom
 
@@ -82,12 +80,12 @@
     get_url:
       url: https://atom.io/download/rpm
       dest: /tmp/atom.rpm
-    when: atom_installed.stat.exists == False
+    when: not atom_installed.stat.exists
 
   - name: Install Atom RPM
     dnf:
       name: /tmp/atom.rpm
       state: present
-    when: atom_installed.stat.exists == False
+    when: not atom_installed.stat.exists
 
   when: install_atom

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -1,4 +1,4 @@
---- 
+---
 
 - name: Create Vagrant group
   group:
@@ -35,4 +35,4 @@
     group: "{{ local_user }}"
 
 - name: Run restorecon on /home/{{ local_user }}/.cert
-  command: /usr/sbin/restorecon -R -v /home/{{ local_user }}/.cert
+  command: /usr/sbin/restorecon -R -v /home/{{ local_user }}/.cert # noqa 301


### PR DESCRIPTION
This updates the meta file and gets ansible-lint to stop moaning about whitespace and 

* [403] Package installs should not use latest
* E601: Don't compare to literal True/False
* [301] Commands should not change things if nothing needs doing